### PR TITLE
Disble autoupload check in ticket channels

### DIFF
--- a/data.json
+++ b/data.json
@@ -4,5 +4,6 @@
     "Discord Admin",
     "Mods"
   ],
-  "member_role": "821071696848093284"
+  "member_role": "821071696848093284",
+  "tickets_category": "549328091005321218"
 }

--- a/modules/autoupload.js
+++ b/modules/autoupload.js
@@ -1,5 +1,6 @@
 const mimeType = require('mime-types')
 const axios = require('axios')
+const { tickets_category } = require('../data.json')
 
 const contentTypes = ['application/json', 'text/plain', 'text/yaml']
 const bytebin = 'https://bytebin.lucko.me'
@@ -8,6 +9,9 @@ module.exports = client => {
   client.on('message', async message => {
     if (message.channel.type !== 'text' || message.author.bot) return
     if (!message.attachments) return
+    // If the message is sent in a ticket channel, do not send the notification
+    if (message.channel.parentID === tickets_category) return
+
     for (const attachment of message.attachments.values()) {
       const contentType = mimeType.lookup(attachment.url)
       if (!contentTypes.some(type => contentType === type)) continue


### PR DESCRIPTION
I think that we should remove the "use bytebin" notifications from ticket channels as it's better to keep all the logs in the channel itself. Besides, a few updates ago, discord got the functionality that shows you `.txt` attachment content in the app itself in a codeblock.