### PR TITLE
[codex] update staff ping support reply

### DIFF
--- a/src/modules/no-ping.ts
+++ b/src/modules/no-ping.ts
@@ -36,7 +36,9 @@ export default (client: Client): void => {
     if (mentionsStaff === true) {
       // Tell them off:
       await message.reply(
-        `Hey ${message.member?.nickname ?? message.author.username}! Please don't tag staff members directly.`,
+        `Hi ${message.member?.nickname ?? message.author.username}! Free public support is currently not very fast because we can't afford doing free support 24/7 because we have other projects to work on and other responsibilities IRL. If this matter is important to you and you want to receive priority & private support, go to <#1314315764253200394> or https://skinsrestorer.net/pricing
+
+-# If your message was not about support or a feature request, ignore this message.`,
       );
     }
   });


### PR DESCRIPTION
## Summary
- Updates the no-ping staff reply to explain the current public support limits.
- Points users to the priority private support channel and pricing page.
- Adds the Discord small-text note for non-support or non-feature-request messages.

## Impact
Users who ping staff now receive the updated support guidance instead of the old direct-tag warning.

## Validation
- `npm run check`
- `npm run typecheck`