### PR TITLE
[codex] mention users in chatbot replies

### DIFF
--- a/src/modules/chatbot.ts
+++ b/src/modules/chatbot.ts
@@ -6,6 +6,8 @@ const SUPPORT_GENERATION_ERROR_MESSAGE =
   "I hit an internal error while generating a reply. Please try again in a moment.";
 const PROMPT_INJECTION_ERROR_MESSAGE =
   "I can't follow instructions that change my role or rules. I can only help with SkinsRestorer support, so share your setup, logs, or `/sr dump` if you need help.";
+const AI_SCOPE_REFUSAL_MESSAGE =
+  "I cannot assist with that request. My purpose is to help with SkinsRestorer setup and troubleshooting. Please let me know if you have any questions about SkinsRestorer.";
 
 type Context = {
   isGenerating: () => boolean;
@@ -28,9 +30,11 @@ export default async (client: Client): Promise<void> => {
       message: Message,
       content: string,
     ): Promise<boolean> => {
+      const replyContent = prefixScopeRefusalWithMention(message, content);
+
       if (!message.system) {
         try {
-          await message.reply(content);
+          await message.reply(replyContent);
           return true;
         } catch (error) {
           console.error(error);
@@ -38,7 +42,7 @@ export default async (client: Client): Promise<void> => {
       }
 
       try {
-        await channel.send(content);
+        await channel.send(replyContent);
         return true;
       } catch (error) {
         console.error(error);
@@ -143,4 +147,15 @@ function debounce<TArgs extends unknown[]>(
       void fn(...args);
     }, delay);
   };
+}
+
+function prefixScopeRefusalWithMention(
+  message: Message,
+  content: string,
+): string {
+  if (content.trim() !== AI_SCOPE_REFUSAL_MESSAGE) {
+    return content;
+  }
+
+  return `<@${message.author.id}> ${content}`;
 }

--- a/src/modules/chatbot.ts
+++ b/src/modules/chatbot.ts
@@ -6,8 +6,6 @@ const SUPPORT_GENERATION_ERROR_MESSAGE =
   "I hit an internal error while generating a reply. Please try again in a moment.";
 const PROMPT_INJECTION_ERROR_MESSAGE =
   "I can't follow instructions that change my role or rules. I can only help with SkinsRestorer support, so share your setup, logs, or `/sr dump` if you need help.";
-const AI_SCOPE_REFUSAL_MESSAGE =
-  "I cannot assist with that request. My purpose is to help with SkinsRestorer setup and troubleshooting. Please let me know if you have any questions about SkinsRestorer.";
 
 type Context = {
   isGenerating: () => boolean;
@@ -30,7 +28,7 @@ export default async (client: Client): Promise<void> => {
       message: Message,
       content: string,
     ): Promise<boolean> => {
-      const replyContent = prefixScopeRefusalWithMention(message, content);
+      const replyContent = prefixWithMention(message, content);
 
       if (!message.system) {
         try {
@@ -149,13 +147,11 @@ function debounce<TArgs extends unknown[]>(
   };
 }
 
-function prefixScopeRefusalWithMention(
-  message: Message,
-  content: string,
-): string {
-  if (content.trim() !== AI_SCOPE_REFUSAL_MESSAGE) {
+function prefixWithMention(message: Message, content: string): string {
+  const mention = `<@${message.author.id}>`;
+  if (content.startsWith(mention)) {
     return content;
   }
 
-  return `<@${message.author.id}> ${content}`;
+  return `${mention} ${content}`;
 }


### PR DESCRIPTION
## Summary
- Prefixes every AI chatbot reply with an explicit Discord user mention.
- Keeps the mention prefix centralized in the chatbot reply helper.
- Avoids adding a duplicate prefix if content is already prefixed for the same user.

## Impact
Chatbot responses in `chat-experiment*` channels now start with `<@userId>` for generated answers, prompt-injection refusals, fallback sends, and internal error replies.

## Validation
- `npm run check`
- `npm run typecheck`